### PR TITLE
Added TM symbol and changed to Gradient AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-![Header image for the DigitalOcean Gradient AI Agentic Cloud](https://doimages.nyc3.cdn.digitaloceanspaces.com/do_gradient_ai_agentic_cloud.svg)
+![Header image for the DigitalOcean Gradient™ AI Agentic Cloud](https://doimages.nyc3.cdn.digitaloceanspaces.com/do_gradient_ai_agentic_cloud.svg)
 
-# 🚀 Gradient Platform Agent Templates
+# 🚀 Gradient™ AI Platform Agent Templates
 **Welcome, builder! 👋**
 
 Ready to bring your AI agent ideas to life? You're in the right place!
 
-This repository offers easy-to-use templates designed to help you launch powerful AI agents on DigitalOcean's Gradient Platform in just a few minutes. Think of this as your personal launchpad: simply clone a template, tweak a few settings, and deploy your agent directly to the cloud. You can pick from:
+This repository offers easy-to-use templates designed to help you launch powerful AI agents on DigitalOcean's Gradient AI Platform in just a few minutes. Think of this as your personal launchpad: simply clone a template, tweak a few settings, and deploy your agent directly to the cloud. You can pick from:
 - **[LLM Auditor Agent](llm-auditor)**: Acts as a fact checking layer that searches the internet using the [Tavily API](https://www.tavily.com/) and optionally uses grounding data from a knowledge base to help improve the reliability of an existing agent.
 - **[Product Documentation Agent](pdocs-agent)**: Answers questions from your customers about your products based on documentation.
 - **[SQL Agent](sql-agent)**: Connects to your existing MySQL database and translates natural language questions into SQL queries, then analyzes the results. The agent dynamically fetches your database schema to craft intelligent queries and is restricted to read-only operations for security.

--- a/llm-auditor/README.md
+++ b/llm-auditor/README.md
@@ -50,7 +50,7 @@ doctl auth switch --context <your-context>
 
 * **Ensure access to LLaMA 3.3**:
 
-  * Ensure you have accepted the terms and conditions to use LLaMA 3.3 70B on the DigitalOcean Gradient Platform. You can do this by manually creating a new agent using LLaMA 3.3 70B as the base model.
+  * Ensure you have accepted the terms and conditions to use LLaMA 3.3 70B on the DigitalOcean Gradient™ AI Platform. You can do this by manually creating a new agent using LLaMA 3.3 70B as the base model.
 
 * **Tavily API Key**:
 
@@ -112,7 +112,7 @@ REGION=tor1
 
 ## 📄 Notes
 
-* The ADK version of this sample agent uses sub-agents. The DigitalOcean Gradient Platform  currently only supports routing requests from one agent to another. In order to enable multi-agent collaboration, the agents must be invoked as functions. Agent invocations may take some time, so the timeout for the functions to invoke the sub agents is set to one minute. 
+* The ADK version of this sample agent uses sub-agents. The DigitalOcean Gradient AI Platform  currently only supports routing requests from one agent to another. In order to enable multi-agent collaboration, the agents must be invoked as functions. Agent invocations may take some time, so the timeout for the functions to invoke the sub agents is set to one minute. 
 * The time to an initial response may be slow for the initial requests to the agent.  
 * All the functions are websecure functions. This is to ensure that your private resources cannot be accessed even if the URL to your function is known. Ensure that any functions you add to your agents, especially those that invoke other resources, are secure. 
 * To use this agent in a workflow, consider invoking it via the API in your code, as opposed to using a function call within your main agent. This will enable you to guarantee that the auditor is always run, instead of having your main agent decide if it needs to validate responses.

--- a/pdocs-agent/README.md
+++ b/pdocs-agent/README.md
@@ -1,6 +1,6 @@
 # 📄 Product Documentation QA Agent Template
 
-This project is a template for deploying a Retrieval-Augmented Generation (RAG) agent on the [DigitalOcean Gradient Platform](https://www.digitalocean.com/products/gradient) that answers user questions based on your product documentation. 
+This project is a template for deploying a Retrieval-Augmented Generation (RAG) agent on the [DigitalOcean Gradient™ AI Platform](https://www.digitalocean.com/products/gradient) that answers user questions based on your product documentation. 
 
 This template will do the following:
 
@@ -27,7 +27,7 @@ You will also need:
 
 * A valid DigitalOcean API Token
 * A valid Project ID
-* You must have accepted the terms and conditions to use LLaMA 3.3 70B on the Gradient Platform (you can do this by manually creating a new agent using LLaMA 3.3 70B as the base model).
+* You must have accepted the terms and conditions to use LLaMA 3.3 70B on the Gradient AI Platform (you can do this by manually creating a new agent using LLaMA 3.3 70B as the base model).
 
 
 ## 🛠️ What this Template Does
@@ -38,7 +38,7 @@ When you run `deploy_template.py`, the script:
 2. **Creates a knowledge base** connected to this bucket and indexes your docs.
 
    * You can either create a **new OpenSearch DB** or use an **existing one**.
-3. **Creates a Gradient Platform agent** using the indexed KB.
+3. **Creates a Gradient AI Platform agent** using the indexed KB.
 
    * The agent will be instructed on your product using the name and description provided.
    * The agent is explicitly instructed to not answer questions unrelated to the product, or questions that cannot be answered via the documentation

--- a/sql-agent/README.md
+++ b/sql-agent/README.md
@@ -11,7 +11,7 @@ Before deploying this agent, ensure you have:
 
 2. **DigitalOcean access:**
    - Valid DigitalOcean API token
-   - Sufficient privileges to deploy DigitalOcean Functions and Gradient Platform agents
+   - Sufficient privileges to deploy DigitalOcean Functions and Gradient™ AI Platform agents
    - Optional: Valid `doctl` context
 
 3. **Database:**
@@ -29,7 +29,7 @@ The deployment follows these steps:
 2. **Function Deployment** - Deploys secure web functions via `doctl`:
    - `get_schema` - Fetches database schema information
    - `execute_query` - Executes SELECT queries safely
-3. **Agent Creation** - Creates the Gradient Platform agent using `pydo`
+3. **Agent Creation** - Creates the Gradient AI Platform agent using `pydo`
 4. **Tool Integration** - Attaches the database functions to the agent
 
 ## Usage

--- a/twilio-api-agent/README.md
+++ b/twilio-api-agent/README.md
@@ -1,6 +1,6 @@
 # 📣 Twilio Marketing Agent Template
 
-This project provides a template for deploying a Generative AI Agent that can generate and send marketing text messages using [Twilio](https://www.twilio.com/) on the [DigitalOcean Gradient Platform](https://www.digitalocean.com/products/gradient).
+This project provides a template for deploying a Generative AI Agent that can generate and send marketing text messages using [Twilio](https://www.twilio.com/) on the [DigitalOcean Gradient™ AI Platform](https://www.digitalocean.com/products/gradient).
 
 
 
@@ -32,7 +32,7 @@ pip install -r requirements.txt
 Running the script:
 
 1. Deploys a serverless function** using `doctl serverless` that sends SMS via Twilio's messages API.
-2. Creates a new agent on the DigitalOcean Gradient Platform.
+2. Creates a new agent on the DigitalOcean Gradient AI Platform.
 3. Attaches the Twilio messaging tool to the agent so it can send marketing messages on its own.
 
 


### PR DESCRIPTION
Per legal, we need to always refer to "Gradient AI" and the first instance should include the trademark (™) symbol, e.g. "DigitalOcean Gradient™ AI Platform"